### PR TITLE
Add presignedURLV4() to SimpleStorageSigner

### DIFF
--- a/Sources/SimpleStorageSigner/SimpleStorageSigner+Signing.swift
+++ b/Sources/SimpleStorageSigner/SimpleStorageSigner+Signing.swift
@@ -57,6 +57,19 @@ extension SimpleStorageSigner {
     func path(_ url: URL) -> String {
         return !url.path.isEmpty ? url.path.encode(with: .pathAllowed) ?? "/" : "/"
     }
+
+    public func presignedURLV4(httpMethod: HTTPMethod, url: URL, expiration: Expiration, headers: [String: String]) throws -> URL? {
+        let dates = Dates(Date())
+        var updatedHeaders = headers
+        updatedHeaders["Host"] = url.host ?? region.host
+
+        let (canonRequest, fullURL) = try presignedURLCanonRequest(httpMethod, dates: dates, expiration: expiration, url: url, headers: updatedHeaders)
+
+        let stringToSign = try createStringToSign(canonRequest, dates: dates)
+        let signature = try createSignature(stringToSign, timeStampShort: dates.short)
+        let presignedURL = URL(string: fullURL.absoluteString.appending("&X-Amz-Signature=\(signature)"))
+        return presignedURL
+    }
     
     func presignedURLCanonRequest(_ httpMethod: HTTPMethod, dates: Dates, expiration: Expiration, url: URL, headers: [String: String]) throws -> (String, URL) {
         guard let credScope = self.credentialScope(dates.short).encode(with: .queryAllowed),

--- a/Sources/SimpleStorageSigner/SimpleStorageSigner+Signing.swift
+++ b/Sources/SimpleStorageSigner/SimpleStorageSigner+Signing.swift
@@ -61,12 +61,12 @@ extension SimpleStorageSigner {
     public func presignedURLV4(httpMethod: HTTPMethod, url: URL, expiration: Expiration, headers: [String: String]) throws -> URL? {
         let dates = Dates(Date())
         var updatedHeaders = headers
-        updatedHeaders["Host"] = url.host ?? region.host
+        updatedHeaders["Host"] = url.host ?? self.region.host
 
-        let (canonRequest, fullURL) = try presignedURLCanonRequest(httpMethod, dates: dates, expiration: expiration, url: url, headers: updatedHeaders)
+        let (canonRequest, fullURL) = try self.presignedURLCanonRequest(httpMethod, dates: dates, expiration: expiration, url: url, headers: updatedHeaders)
 
-        let stringToSign = try createStringToSign(canonRequest, dates: dates)
-        let signature = try createSignature(stringToSign, timeStampShort: dates.short)
+        let stringToSign = try self.createStringToSign(canonRequest, dates: dates)
+        let signature = try self.createSignature(stringToSign, timeStampShort: dates.short)
         let presignedURL = URL(string: fullURL.absoluteString.appending("&X-Amz-Signature=\(signature)"))
         return presignedURL
     }


### PR DESCRIPTION
I did this so to produce a usable v4 pre-signed S3 url and expose it so
consumers of this library can use it.